### PR TITLE
Query parameter functionality for contract tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ When running ContractPolice on a regular basis, you can make sure to work with v
 
 ## Usage
 ContractPolice takes a `Contract` defined in YAML and tests a given endpoint.   
-For more details on the defining a contract, see [Contract Definitions](#-contract-definitions)
+For more details on the defining a contract, see [Contract Definitions](#Contract-Definitions)
 
 ### Docker 
 An easy to use Docker image is available on [Docker Hub](https://hub.docker.com/r/rwslinkman/contractpolice).   
@@ -41,7 +41,7 @@ ContractPolice will set the exit status to `0` for success; `1` means a test has
 This can be overriden using the `CP_FAIL_ON_ERROR` environment variable.   
 Pass `-e CP_FAIL_ON_ERROR=false` in the `docker` command to do so.
 
-For more options, see the [Options](#-options) section.
+For more options, see the [Options](#Options) section.
 
 ### Installation
 You could also integrate ContractPolice manually to fit the needs of your project.   

--- a/README.md
+++ b/README.md
@@ -68,12 +68,15 @@ contractPolice
 ## Options
 ContractPolice allows for a (minimal) set of properties to be configured to your desire.   
 
-| Config            | Environment variable (Docker) | Explanation                                                                             | Default value |
-|-------------------|-------------------------------|-----------------------------------------------------------------------------------------|---------------|
-| `failOnError`     | CP_FAIL_ON_ERROR              | Determines the signal given to the CLI after ContractPolice detects contract violations | `true`        |
-| `reporter`        | CP_REPORTER                   | Defines which reporter should be used by ContractPolice.                                | `default`     |
-| `reportOutputDir` | n/a (volume)                  | Allows to set a location for the reports to be placed                                   | `build`       |
-
+| Config                  | Environment variable (Docker) | Explanation                                                                             | Default value |
+|-------------------------|-------------------------------|-----------------------------------------------------------------------------------------|---------------|
+| `failOnError`           | `CP_FAIL_ON_ERROR`            | Determines the signal given to the CLI after ContractPolice detects contract violations | `true`        |
+| `reporter`              | `CP_REPORTER`                 | Defines which reporter should be used by ContractPolice.                                | `default`     |
+| `reportOutputDir`       | n/a (volume)                  | Allows to set a location for the reports to be placed                                   | `build`       |
+| `enableAppLogsConsole`  | `CP_LOGS_CONSOLE_ENABLED`     | Enables console logging of ContractPolice application logs                              | `false`       |
+| `enableAppLogsFile`     | `CP_LOGS_FILE_ENABLED`        | Enables file logging of ContractPolice application logs                                 | `false`       |
+| `loglevel`              | `CP_LOGS_LEVEL`               | Loglevel for ContractPolice application logs (one of `error`, `warn`, `info`, `debug`   | `warn`        |
+| `customValidationRules` | not implemented               | List of custom rules for ContractPolice to use when validating contracts                | `[]`          |
 
 ### Reporter configuration
 ContractPolice is a tool that keeps CI pipelines close to the heart.   
@@ -152,10 +155,35 @@ contract:
     headers:
       Content-Type: application/json
 ```
+#### Request headers
+To add a header to a contract test request, simply specify a `headers` section in the request.   
+It could for example be used to pass an authentication token.   
 
-#### Query paramers
-TODO: how to use
+An example of a contract with request headers looks like this:   
+```yaml
+contract:
+  request:
+    path: /v1/orders/my-order-id
+    headers:
+      X-Custom-Token: someToken
+  response:
+    statusCode: 200
+```
+#### Query parameters
+Query parameters can dynamically be added to a contract test request.   
+All specified `params` will be appended to the request sent to the target API.   
+Parameters can be specified as arrays or objects.   
 
+An example of a contract with query parameters looks like this:   
+```yaml
+contract:
+  request:
+    path: /v1/orders/my-order-id
+    params:
+      token: someToken
+  response:
+    statusCode: 200
+```
 #### Wildcards
 Wildcards can be used if the exact value of the outcome does not matter.   
 Using these wildcards, you can verify the type of the variable, ignoring its exact value.   

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ When running ContractPolice on a regular basis, you can make sure to work with v
 
 ## Usage
 ContractPolice takes a `Contract` defined in YAML and tests a given endpoint.   
-For more details on the defining a contract, see `Contract Definitions`
+For more details on the defining a contract, see [Contract Definitions](#-contract-definitions)
 
 ### Docker 
 An easy to use Docker image is available on [Docker Hub](https://hub.docker.com/r/rwslinkman/contractpolice).   
@@ -27,7 +27,7 @@ docker run \
   -e CP_REPORTER=junit \
   -v $(pwd)/contracts:/contractpolice/ci-contracts \
   -v $(pwd)/build:/contractpolice/outputs \
-  rwslinkman/contractpolice:v0.6.1
+  rwslinkman/contractpolice:v0.7.0
 ```
 
 Define a place to store your contract YAML files and map it to `/contractpolice/ci-contracts`.   
@@ -40,6 +40,8 @@ Most CI systems will automatically do this when you execute the `docker` command
 ContractPolice will set the exit status to `0` for success; `1` means a test has failed or an error occurred.   
 This can be overriden using the `CP_FAIL_ON_ERROR` environment variable.   
 Pass `-e CP_FAIL_ON_ERROR=false` in the `docker` command to do so.
+
+For more options, see the [Options](#-options) section.
 
 ### Installation
 You could also integrate ContractPolice manually to fit the needs of your project.   
@@ -63,7 +65,17 @@ contractPolice
     });
 ```
 
-### Reporting
+## Options
+ContractPolice allows for a (minimal) set of properties to be configured to your desire.   
+
+| Config            | Environment variable (Docker) | Explanation                                                                             | Default value |
+|-------------------|-------------------------------|-----------------------------------------------------------------------------------------|---------------|
+| `failOnError`     | CP_FAIL_ON_ERROR              | Determines the signal given to the CLI after ContractPolice detects contract violations | `true`        |
+| `reporter`        | CP_REPORTER                   | Defines which reporter should be used by ContractPolice.                                | `default`     |
+| `reportOutputDir` | n/a (volume)                  | Allows to set a location for the reports to be placed                                   | `build`       |
+
+
+### Reporter configuration
 ContractPolice is a tool that keeps CI pipelines close to the heart.   
 By default, it generates a `*.txt` file that reports on the APIs contract state.   
 
@@ -78,15 +90,6 @@ const contractPoliceConfig = {
     reportOutputDir: "relative/path/to/outputdir"
 }
 ```
-
-### Configuration
-ContractPolice allows for a (minimal) set of properties to be configured to your desire.   
-
-| Option            | Explanation                                                                             | Default value |
-|-------------------|-----------------------------------------------------------------------------------------|---------------|
-| `failOnError`     | Determines the signal given to the CLI after ContractPolice detects contract violations | `true`        |
-| `reporter`        | Defines which reporter should be used by ContractPolice.                                | `default`     |
-| `reportOutputDir` | Allows to set a location for the reports to be placed                                   | `build`       |
 
 ## Contract Definitions
 ContractPolice uses YAML files that define the contracts you have with a web service.   
@@ -150,6 +153,9 @@ contract:
       Content-Type: application/json
 ```
 
+#### Query paramers
+TODO: how to use
+
 #### Wildcards
 Wildcards can be used if the exact value of the outcome does not matter.   
 Using these wildcards, you can verify the type of the variable, ignoring its exact value.   
@@ -180,6 +186,8 @@ contract:
         - product: Fries
           quantity: 1
           price: 10
+    params:
+      orderId: 1337
   response:
     statusCode: 200
     headers:
@@ -203,7 +211,7 @@ docker run \
   -e CP_REPORTER=junit \
   -v $(pwd)/contracts:/contractpolice/ci-contracts \
   -v $(pwd)/build:/contractpolice/outputs \
-  rwslinkman/contractpolice:v0.6.1
+  rwslinkman/contractpolice:v0.7.0
 ```
 Note: the `$(pwd)/build` directory will be created if it does not exist.   
 

--- a/contracts/v3/create_order_queryparams.yaml
+++ b/contracts/v3/create_order_queryparams.yaml
@@ -5,11 +5,11 @@ contract:
     headers:
       - Accept: application/json
     params:
-      - orderId: abcd-efghi-jklmn-opqrst
-      - token: tsrqpo-nmlkj-ihgfe-bcda
+      - orderId: tsrqpo-nmlkj-ihgfe-bcda
+      - token: abcd-efghi-jklmn-opqrst
   response:
     body:
-      orderId: abcd-efghi-jklmn-opqrst
+      orderId: tsrqpo-nmlkj-ihgfe-bcda
       customer:
         firstname: Rick
         lastname: Slinkman

--- a/contracts/v3/create_order_queryparams.yaml
+++ b/contracts/v3/create_order_queryparams.yaml
@@ -1,29 +1,14 @@
 contract:
   request:
     path: /v3/orders
-    method: POST
-    body:
-      customer: Rick
-      transactionId: <uuid>
-      items:
-        - product: Hamburger
-          quantity: 2
-          price: 20
-        - product: Fries
-          quantity: 1
-          price: 5
-        - product: Chicken nuggets
-          quantity: 1
-          price: 5
-        - product: Milkshake
-          quantity: 2
-          procie: 10
+    method: GET
     headers:
-      - Content-Type: application/json
       - Accept: application/json
+    params:
+      - orderId: abcd-efghi-jklmn-opqrst
   response:
     body:
-      orderId: <anyString>
+      orderId: abcd-efghi-jklmn-opqrst
       customer:
         firstname: Rick
         lastname: Slinkman

--- a/contracts/v3/create_order_queryparams.yaml
+++ b/contracts/v3/create_order_queryparams.yaml
@@ -6,6 +6,7 @@ contract:
       - Accept: application/json
     params:
       - orderId: abcd-efghi-jklmn-opqrst
+      - token: tsrqpo-nmlkj-ihgfe-bcda
   response:
     body:
       orderId: abcd-efghi-jklmn-opqrst

--- a/src/helper-functions.js
+++ b/src/helper-functions.js
@@ -1,5 +1,5 @@
 module.exports = {
-    normalizeHeaders: function(headersObject) {
+    normalizeObject: function(headersObject) {
         if(!Array.isArray(headersObject)) {
             headersObject = Object.entries(headersObject);
         }

--- a/src/parsing/contractparser.js
+++ b/src/parsing/contractparser.js
@@ -85,7 +85,7 @@ ContractParser.prototype.parseContract = function (contractsDirectory, contractF
     this.logger.debug(LOG_TAG, `File '${contractName}' contains a valid Contract Definition`);
 
     // TODO: simplify, extract function
-    // Verify within request
+    // Verify headers within request
     let expectedRequest = contractYaml.contract.request;
     if (expectedRequest.hasOwnProperty("headers")) {
         let requestHeaders = contractYaml.contract.request.headers;
@@ -94,12 +94,12 @@ ContractParser.prototype.parseContract = function (contractsDirectory, contractF
         }
 
         // Formatting headers into desired format; supporting both Object an Array notation
-        requestHeaders = helper.normalizeHeaders(requestHeaders);
+        requestHeaders = helper.normalizeObject(requestHeaders);
         contractYaml.contract.request.headers = requestHeaders;
         this.logger.debug(LOG_TAG, `Request headers of '${contractName}' have been normalized`);
     }
 
-    // Verify within response
+    // Verify headers within response
     let expectedResponse = contractYaml.contract.response;
     if (expectedResponse.hasOwnProperty("headers")) {
         let responseHeaders = contractYaml.contract.response.headers;
@@ -108,12 +108,23 @@ ContractParser.prototype.parseContract = function (contractsDirectory, contractF
         }
 
         // Formatting headers into desired format; supporting both Object an Array notation
-        responseHeaders = helper.normalizeHeaders(responseHeaders);
+        responseHeaders = helper.normalizeObject(responseHeaders);
         contractYaml.contract.response.headers = responseHeaders;
         this.logger.debug(LOG_TAG, `Response headers of '${contractName}' have been normalized`);
     }
 
     // TODO Validate/normalize queryparams
+    // Verify query parameters within request
+    if(expectedRequest.hasOwnProperty("params")) {
+        let requestQueryParams = contractYaml.contract.request.params;
+        if(typeof requestQueryParams !== "object") {
+            throw `Query parameter definition in '${contractName}' should be of type 'object' or 'array'`;
+        }
+
+        requestQueryParams = helper.normalizeObject(requestQueryParams);
+        contractYaml.contract.request.params = requestQueryParams;
+        this.logger.debug(LOG_TAG, `Query params of '${contractName}' have been normalized`);
+    }
 
     return {
         name: contractName,

--- a/src/parsing/contractparser.js
+++ b/src/parsing/contractparser.js
@@ -36,6 +36,20 @@ function extractContractName(baseDir, contractFile) {
         .replace(".yml", "");
 }
 
+function normalizeObjectProperty(logger, target, propertyName, contractName) {
+    if (target.hasOwnProperty(propertyName)) {
+        let targetObject = target[propertyName];
+        if (typeof targetObject !== "object") {
+            throw `Definition of '${propertyName}' in '${contractName}' should be of type 'object' or 'array'`;
+        }
+
+        // Formatting headers into desired format; supporting both Object an Array notation
+        targetObject = helper.normalizeObject(targetObject);
+        target[propertyName] = targetObject;
+        logger.debug(LOG_TAG, `Definition of '${propertyName}' in '${contractName}' have been normalized`);
+    }
+}
+
 function ContractParser(logger) {
     this.logger = logger;
 }
@@ -84,47 +98,10 @@ ContractParser.prototype.parseContract = function (contractsDirectory, contractF
     // All expected properties exist, no error thrown.
     this.logger.debug(LOG_TAG, `File '${contractName}' contains a valid Contract Definition`);
 
-    // TODO: simplify, extract function
-    // Verify headers within request
-    let expectedRequest = contractYaml.contract.request;
-    if (expectedRequest.hasOwnProperty("headers")) {
-        let requestHeaders = contractYaml.contract.request.headers;
-        if (typeof requestHeaders !== "object") {
-            throw `Request header definition in '${contractName}' should be of type 'object' or 'array'`;
-        }
-
-        // Formatting headers into desired format; supporting both Object an Array notation
-        requestHeaders = helper.normalizeObject(requestHeaders);
-        contractYaml.contract.request.headers = requestHeaders;
-        this.logger.debug(LOG_TAG, `Request headers of '${contractName}' have been normalized`);
-    }
-
-    // Verify headers within response
-    let expectedResponse = contractYaml.contract.response;
-    if (expectedResponse.hasOwnProperty("headers")) {
-        let responseHeaders = contractYaml.contract.response.headers;
-        if (typeof responseHeaders !== "object") {
-            throw `Response header definition in '${contractName}' should be of type 'object' or 'array'`;
-        }
-
-        // Formatting headers into desired format; supporting both Object an Array notation
-        responseHeaders = helper.normalizeObject(responseHeaders);
-        contractYaml.contract.response.headers = responseHeaders;
-        this.logger.debug(LOG_TAG, `Response headers of '${contractName}' have been normalized`);
-    }
-
-    // TODO Validate/normalize queryparams
-    // Verify query parameters within request
-    if(expectedRequest.hasOwnProperty("params")) {
-        let requestQueryParams = contractYaml.contract.request.params;
-        if(typeof requestQueryParams !== "object") {
-            throw `Query parameter definition in '${contractName}' should be of type 'object' or 'array'`;
-        }
-
-        requestQueryParams = helper.normalizeObject(requestQueryParams);
-        contractYaml.contract.request.params = requestQueryParams;
-        this.logger.debug(LOG_TAG, `Query params of '${contractName}' have been normalized`);
-    }
+    // Verify objects within request & response
+    normalizeObjectProperty(this.logger, contractYaml.contract.request, "headers", contractName);
+    normalizeObjectProperty(this.logger, contractYaml.contract.response, "headers", contractName);
+    normalizeObjectProperty(this.logger, contractYaml.contract.request, "params", contractName);
 
     return {
         name: contractName,

--- a/src/parsing/contractparser.js
+++ b/src/parsing/contractparser.js
@@ -84,6 +84,7 @@ ContractParser.prototype.parseContract = function (contractsDirectory, contractF
     // All expected properties exist, no error thrown.
     this.logger.debug(LOG_TAG, `File '${contractName}' contains a valid Contract Definition`);
 
+    // TODO: simplify, extract function
     // Verify within request
     let expectedRequest = contractYaml.contract.request;
     if (expectedRequest.hasOwnProperty("headers")) {
@@ -111,6 +112,8 @@ ContractParser.prototype.parseContract = function (contractsDirectory, contractF
         contractYaml.contract.response.headers = responseHeaders;
         this.logger.debug(LOG_TAG, `Response headers of '${contractName}' have been normalized`);
     }
+
+    // TODO Validate/normalize queryparams
 
     return {
         name: contractName,

--- a/src/testrunner.js
+++ b/src/testrunner.js
@@ -50,10 +50,16 @@ TestRunner.prototype.runTest = function() {
                     loggerLocal.info(LOG_TAG, `Contract test "${testNameLocal}" completed with result ${testResult}`);
                     return new TestOutcome(testNameLocal, violationReport.getViolationTexts(), testResult);
                 })
+                .catch(function(validatorError) {
+                    // Validation error
+                    let violationText = `Unable to validate ${testNameLocal} due to error`;
+                    loggerLocal.error(LOG_TAG, `${violationText}: ${validatorError.message}`);
+                    return new TestOutcome(testNameLocal, [violationText], "FAIL");
+                })
         })
         .catch(function(needleError) {
-            loggerLocal.error(LOG_TAG, `Cannot reach testing target at "${needleError.address}:${needleError.port}" (errorcode: ${needleError.code})`);
             // HTTP request error
+            loggerLocal.error(LOG_TAG, `Cannot reach testing target at "${needleError.address}:${needleError.port}" (errorcode: ${needleError.code})`);
             let violationText = `ContractPolice contacted ${url} but was unable to reach it`;
             return new TestOutcome(testNameLocal, [violationText], "FAIL");
         });

--- a/src/testrunner.js
+++ b/src/testrunner.js
@@ -4,15 +4,15 @@ const helper = require("./helper-functions.js");
 const LOG_TAG = "TestRunner";
 
 function formatUrl(target, endpoint, queryParams) {
-    let url = target + endpoint;
-    if(queryParams.length > 0) {
-        url += "?";
-        queryParams.forEach(function(param) {
-            let key = Object.keys(param)[0];
-            url += `${key}=${param[key]}`;
-        })
+    if(target.endsWith("/") && endpoint.startsWith("/")) {
+        endpoint = endpoint.substr(1);
     }
-    return url;
+    let url = new URL(target + endpoint);
+    queryParams.forEach(function(param) {
+        let key = Object.keys(param)[0];
+        url.searchParams.append(key, param[key]);
+    })
+    return url.toString();
 }
 
 
@@ -48,7 +48,6 @@ TestRunner.prototype.runTest = function() {
     const endpoint = formatUrl(this.target, contractRequest.path, contractQueryParams);
     loggerLocal.debug(LOG_TAG, `Creating request to endpoint: ${method.toUpperCase()} ${endpoint}`);
 
-    console.log(endpoint);
     let request;
     if(method.toUpperCase() === "GET") {
         request = needle('get', endpoint, options);

--- a/src/testrunner.js
+++ b/src/testrunner.js
@@ -3,11 +3,24 @@ const TestOutcome = require("./testoutcome.js");
 const helper = require("./helper-functions.js");
 const LOG_TAG = "TestRunner";
 
-function TestRunner(logger, name, contractRequest, endpoint, validator) {
+function formatUrl(target, endpoint, queryParams) {
+    let url = target + endpoint;
+    if(queryParams.length > 0) {
+        url += "?";
+        queryParams.forEach(function(param) {
+            let key = Object.keys(param)[0];
+            url += `${key}=${param[key]}`;
+        })
+    }
+    return url;
+}
+
+
+function TestRunner(logger, name, contractRequest, target, validator) {
     this.logger = logger;
     this.testName = name;
     this.contractRequest = contractRequest;
-    this.endpoint = endpoint;
+    this.target = target;
     this.validator = validator;
 }
 
@@ -19,27 +32,32 @@ TestRunner.prototype.runTest = function() {
     loggerLocal.info(LOG_TAG, `Executing "${testNameLocal}" contract test `)
 
     const method = contractRequest.method || "GET";
-    const url = this.endpoint + contractRequest.path;
     const options = {
         json: true
     };
     const data = contractRequest.body || {};
+    // Headers
     let contractHeaders = contractRequest.headers || [];
-    contractHeaders = helper.normalizeHeaders(contractHeaders);
+    contractHeaders = helper.normalizeObject(contractHeaders);
     if(contractHeaders.length > 0) {
         options["headers"] = contractHeaders;
     }
-    loggerLocal.debug(LOG_TAG, `Creating request to endpoint: ${method.toUpperCase()} ${url}`);
+    // Query params
+    let contractQueryParams = contractRequest.params || [];
+    // Endpoint
+    const endpoint = formatUrl(this.target, contractRequest.path, contractQueryParams);
+    loggerLocal.debug(LOG_TAG, `Creating request to endpoint: ${method.toUpperCase()} ${endpoint}`);
 
+    console.log(endpoint);
     let request;
     if(method.toUpperCase() === "GET") {
-        request = needle('get', url, options);
+        request = needle('get', endpoint, options);
     } else {
-        request = needle(method.toLowerCase(), url, data, options);
+        request = needle(method.toLowerCase(), endpoint, data, options);
     }
     return request
         .then(function(response) {
-            loggerLocal.debug(LOG_TAG, `Response statuscode [${response.statusCode}] at ${method.toUpperCase()} ${url}`);
+            loggerLocal.debug(LOG_TAG, `Response statuscode [${response.statusCode}] at ${method.toUpperCase()} ${endpoint}`);
             // Validate HTTP response
             return validator
                 .validate(response)
@@ -60,7 +78,7 @@ TestRunner.prototype.runTest = function() {
         .catch(function(needleError) {
             // HTTP request error
             loggerLocal.error(LOG_TAG, `Cannot reach testing target at "${needleError.address}:${needleError.port}" (errorcode: ${needleError.code})`);
-            let violationText = `ContractPolice contacted ${url} but was unable to reach it`;
+            let violationText = `ContractPolice contacted ${endpoint} but was unable to reach it`;
             return new TestOutcome(testNameLocal, [violationText], "FAIL");
         });
 };

--- a/src/validation/validator.js
+++ b/src/validation/validator.js
@@ -14,8 +14,9 @@ function validateStatusCode(logger, expectedResponse, actualResponse) {
 }
 
 function validateAllKeysExist(logger, expectedResponse, actualResponse) {
-    let bodyTypeViolations = validateMatchingBodyType(logger, expectedResponse, actualResponse);
-    if(bodyTypeViolations.length === 0) {
+    let violations = validateMatchingBodyType(logger, expectedResponse, actualResponse);
+    violations = violations.concat(validateStatusCode(logger, expectedResponse, actualResponse));
+    if(violations.length === 0) {
         // Validation is only needed when types are the same
         return deepCompare(expectedResponse.body, actualResponse.body);
     }

--- a/test/parsing/contractparser.spec.js
+++ b/test/parsing/contractparser.spec.js
@@ -318,7 +318,7 @@ describe("ContractParser", () => {
 
             const parser = new ContractParser(TESTLOGGER);
 
-            expect(() => parser.parseContract(testBaseDir, testFilePath1)).to.throw("Request header definition in 'contract1' should be of type 'object' or 'array'");
+            expect(() => parser.parseContract(testBaseDir, testFilePath1)).to.throw("Definition of 'headers' in 'contract1' should be of type 'object' or 'array'");
         });
 
         it("should normalize response headers to array when headers are specified as object", () => {
@@ -393,7 +393,7 @@ describe("ContractParser", () => {
 
             const parser = new ContractParser(TESTLOGGER);
 
-            expect(() => parser.parseContract(testBaseDir, testFilePath1)).to.throw("Response header definition in 'contract1' should be of type 'object' or 'array'");
+            expect(() => parser.parseContract(testBaseDir, testFilePath1)).to.throw("Definition of 'headers' in 'contract1' should be of type 'object' or 'array'");
         });
         //endregion
 
@@ -472,7 +472,7 @@ describe("ContractParser", () => {
 
             const parser = new ContractParser(TESTLOGGER);
 
-            expect(() => parser.parseContract(testBaseDir, testFilePath1)).to.throw("Query parameter definition in 'contract1' should be of type 'object' or 'array'");
+            expect(() => parser.parseContract(testBaseDir, testFilePath1)).to.throw("Definition of 'params' in 'contract1' should be of type 'object' or 'array'");
         });
         // endregion
     })

--- a/test/parsing/contractparser.spec.js
+++ b/test/parsing/contractparser.spec.js
@@ -90,6 +90,7 @@ describe("ContractParser", () => {
             });
         }
 
+        //region basic contract test
         it("should return the contract object when given valid input", () => {
             const yamlContent = {
                 contract: {
@@ -242,7 +243,9 @@ describe("ContractParser", () => {
 
             expect(() => parser.parseContract(testBaseDir, testFilePath1)).to.throw(`contract1 does not contain a "contract.response.statusCode"`);
         });
+        //endregion
 
+        //region header tests
         it("should normalize request headers to array when headers are specified as object", () => {
             const yamlContent = {
                 contract: {
@@ -392,5 +395,85 @@ describe("ContractParser", () => {
 
             expect(() => parser.parseContract(testBaseDir, testFilePath1)).to.throw("Response header definition in 'contract1' should be of type 'object' or 'array'");
         });
+        //endregion
+
+        //region
+        it("should normalize query parameters to array when params are specified as object", () => {
+            const yamlContent = {
+                contract: {
+                    request: {
+                        path: "/some/path",
+                        params: {
+                            orderId: 1337,
+                            token: "abcd"
+                        }
+                    },
+                    response: {
+                        statusCode: 200
+                    }
+                }
+            };
+            mockYamlLoading(yamlContent);
+
+            const parser = new ContractParser(TESTLOGGER);
+            let result = parser.parseContract(testBaseDir, testFilePath1);
+
+            expect(result.data).to.equal(yamlContent.contract);
+            expect(result.name).to.equal(testFileName1);
+            const payload = result.data;
+            expect(payload.request.params).to.deep.equal([
+                { "orderId": 1337 },
+                { "token": "abcd" }
+            ]);
+        });
+
+        it("should normalize query parameters to array when params are specified as array", () => {
+            const yamlContent = {
+                contract: {
+                    request: {
+                        path: "/some/path",
+                        params: [
+                            { "orderId": 1337 },
+                            { "token": "abcd" }
+                        ]
+                    },
+                    response: {
+                        statusCode: 200
+                    }
+                }
+            };
+            mockYamlLoading(yamlContent);
+
+            const parser = new ContractParser(TESTLOGGER);
+            let result = parser.parseContract(testBaseDir, testFilePath1);
+
+            expect(result.data).to.equal(yamlContent.contract);
+            expect(result.name).to.equal(testFileName1);
+            const payload = result.data;
+            expect(payload.request.params).to.deep.equal([
+                { "orderId": 1337 },
+                { "token": "abcd" }
+            ]);
+        });
+
+        it("should throw an error when query parameters are specified as non-object type", () => {
+            const yamlContent = {
+                contract: {
+                    request: {
+                        path: "/some/path",
+                        params: "orderId=1337"
+                    },
+                    response: {
+                        statusCode: 200
+                    }
+                }
+            };
+            mockYamlLoading(yamlContent);
+
+            const parser = new ContractParser(TESTLOGGER);
+
+            expect(() => parser.parseContract(testBaseDir, testFilePath1)).to.throw("Query parameter definition in 'contract1' should be of type 'object' or 'array'");
+        });
+        // endregion
     })
 });

--- a/test/testrunner.spec.js
+++ b/test/testrunner.spec.js
@@ -14,7 +14,7 @@ const TestRunner = rewire("../src/testrunner.js");
 
 describe("TestRunner", () => {
     const testLogger = new Logging("debug", false, false);
-    let needleStub = sinon.stub();
+    let needleStub
     function mockValidator(violations = []) {
         return {
             validate: sinon
@@ -31,14 +31,24 @@ describe("TestRunner", () => {
         });
     }
 
+    beforeEach(function () {
+        needleStub = sinon.stub();
+    });
+
+    afterEach(function() {
+        needleStub.reset();
+    });
+
     it("should run the test when minimal request succeeds and validator returns no violations", () => {
         const request = {
             path: "/v1/orders"
         };
         const violationList = [];
+        const mockedResponse = {
+            statusCode: 200
+        };
         const validator = mockValidator(violationList);
-        const httpSuccess = true;
-        mockNeedleRequest(httpSuccess);
+        mockNeedleRequest(mockedResponse);
 
         const runner = new TestRunner(testLogger, "testName", request, "http://doesnot.exist/", validator);
 
@@ -53,9 +63,11 @@ describe("TestRunner", () => {
             method: "POST"
         };
         const violationList = [];
+        const mockedResponse = {
+            statusCode: 200
+        };
         const validator = mockValidator(violationList);
-        const httpSuccess = true;
-        mockNeedleRequest(httpSuccess);
+        mockNeedleRequest(mockedResponse);
 
         const runner = new TestRunner(testLogger, "testName", request, "http://doesnot.exist/", validator);
 
@@ -70,9 +82,11 @@ describe("TestRunner", () => {
             method: "post"
         };
         const violationList = [];
+        const mockedResponse = {
+            statusCode: 200
+        };
         const validator = mockValidator(violationList);
-        const httpSuccess = true;
-        mockNeedleRequest(httpSuccess);
+        mockNeedleRequest(mockedResponse);
 
         const runner = new TestRunner(testLogger, "testName", request, "http://doesnot.exist/", validator);
 
@@ -87,9 +101,11 @@ describe("TestRunner", () => {
             method: "PUT"
         };
         const violationList = [];
+        const mockedResponse = {
+            statusCode: 200
+        };
         const validator = mockValidator(violationList);
-        const httpSuccess = true;
-        mockNeedleRequest(httpSuccess);
+        mockNeedleRequest(mockedResponse);
 
         const runner = new TestRunner(testLogger, "testName", request, "http://doesnot.exist/", validator);
 
@@ -104,9 +120,11 @@ describe("TestRunner", () => {
             method: "put"
         };
         const violationList = [];
+        const mockedResponse = {
+            statusCode: 200
+        };
         const validator = mockValidator(violationList);
-        const httpSuccess = true;
-        mockNeedleRequest(httpSuccess);
+        mockNeedleRequest(mockedResponse);
 
         const runner = new TestRunner(testLogger, "testName", request, "http://doesnot.exist/", validator);
 
@@ -165,14 +183,42 @@ describe("TestRunner", () => {
             ]
         };
         const violationList = [];
+        const mockedResponse = {
+            statusCode: 200
+        };
         const validator = mockValidator(violationList);
-        const httpSuccess = true;
-        mockNeedleRequest(httpSuccess);
+        mockNeedleRequest(mockedResponse);
 
         const runner = new TestRunner(testLogger, "testName", request, "http://doesnot.exist/", validator);
 
         const result = runner.runTest();
 
         return expect(result).to.eventually.be.fulfilled;
+    });
+
+    it("should append query parameters to URL when running the test", () => {
+        const request = {
+            path: "/v3/orders",
+            method: "GET",
+            params: [
+                { "orderId": 1337 },
+                { "token": "abcd" }
+            ]
+        };
+
+        const violationList = [];
+        const mockedResponse = {
+            statusCode: 200
+        };
+        const validator = mockValidator(violationList);
+        mockNeedleRequest(mockedResponse);
+
+        const runner = new TestRunner(testLogger, "testName", request, "http://doesnot.exist/api", validator);
+
+        runner.runTest();
+
+        const callArguments = needleStub.getCall(0).args;
+        const urlArgument = callArguments[1];
+        return expect(urlArgument).to.equal("http://doesnot.exist/api/v3/orders?orderId=1337&token=abcd");
     });
 });


### PR DESCRIPTION
Allows specification of query parameters in Contract Definitions.
They can be added as arrays or objects under `contract.request.params`

Further improvements:
- README update
- Improvements in tests