### PR TITLE
Feature: Generating values in contract test requests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 11.x, 12.x, 13.x, 14.x]
+        node-version: [12.x, 13.x, 14.x]
     steps:
     - uses: actions/checkout@v2
       name: Checkout

--- a/README.md
+++ b/README.md
@@ -3,6 +3,23 @@ ContractPolice helps you find contract violations in REST APIs fast and easily!
 
 Lightweight Node HTTP client that validates a API contract on a given endpoint.
 
+#### Table of Content
+ * [About ContractPolice](#About-ContractPolice)
+ * [Usage](#Usage)
+     * [Docker](#Docker) 
+     * [Installation in your project](#Installation-in-your-project)
+ * [Options](#Options)
+    * [Reporter configuration](#Reporter-configuration)
+ * [Contract Definitions](#Contract-Definitions)
+    * [Basics](#Basics)
+    * [Response body validation](#Response-body-validation)
+    * [Response header validation](#Response-header-validation)
+    * [Request headers](#Request-headers)
+    * [Query parameters](#Query-parameters)
+    * [Response-wildcards](#Response-wildcards)
+    * [Request data generation](#Request-data-generation)
+ * [Full example](#Full-example) 
+
 ## About ContractPolice
 Many applications depend on a web service to deliver data and fetch configuration using HTTP.   
 In most cases, this is done using a REST API.   
@@ -43,7 +60,7 @@ Pass `-e CP_FAIL_ON_ERROR=false` in the `docker` command to do so.
 
 For more options, see the [Options](#Options) section.
 
-### Installation
+### Installation in your project
 You could also integrate ContractPolice manually to fit the needs of your project.   
 Create a basic NodeJS project and include ContractPolice to the dependency list.   
 ```bash
@@ -64,6 +81,7 @@ contractPolice
         // Violations found
     });
 ```
+**Note:** ContractPolice requires Node version >= 12
 
 ## Options
 ContractPolice allows for a (minimal) set of properties to be configured to your desire.   
@@ -155,6 +173,7 @@ contract:
     headers:
       Content-Type: application/json
 ```
+
 #### Request headers
 To add a header to a contract test request, simply specify a `headers` section in the request.   
 It could for example be used to pass an authentication token.   
@@ -169,6 +188,7 @@ contract:
   response:
     statusCode: 200
 ```
+
 #### Query parameters
 Query parameters can dynamically be added to a contract test request.   
 All specified `params` will be appended to the request sent to the target API.   
@@ -184,8 +204,9 @@ contract:
   response:
     statusCode: 200
 ```
-#### Wildcards
-Wildcards can be used if the exact value of the outcome does not matter.   
+
+#### Response wildcards
+Wildcards can be used if the exact value of the response does not matter.   
 Using these wildcards, you can verify the type of the variable, ignoring its exact value.   
 
 Within the `contract.response` object it is possible to use the following wildcards:   
@@ -195,6 +216,37 @@ Within the `contract.response` object it is possible to use the following wildca
 | `<anyString>` | Verifies that the value is a string of any length  |
 | `<anyNumber>` | Verifies that the value is any number              |   
 | `<anyBool>`   | Verifies that the value is any boolean             |   
+
+#### Request data generation
+To make contract tests less predictive, its also possible to generate data for your requests.   
+It is possible to generate strings, numbers, booleans and UUIDs.   
+Use these in the `contract.request` part of the Contract Definition.   
+
+A generated value can be defined like this:      
+`<generate[type(arg1=val1;arg2=val2)]>`   
+
+The supported types are `string`, `number`, `bool`, and `uuid`.     
+Providing arguments is optional, if applicable they must be noted in the following format:   
+`argument=value`
+
+Some of the variable types take arguments when generating the desired value.
+
+| Supported type | Arguments    |
+|----------------|--------------|
+| string         | `length`     |
+| number         | `min`, `max` |
+| bool           | none         |
+| uuid           | none         |
+
+Some examples:   
+
+| Example                             | Explanation                                        |
+|-------------------------------------|----------------------------------------------------|
+| `<generate[string]>`                | Injects a random string in the request             |
+| `<generate[string(length=32)]>`     | Injects a random of 32 characters string           |
+| `<generate[number(min=10;max=31)]>` | Injects a random number between 10 and 31          |   
+| `<generate[bool]>`                  | Injects a random boolean (true/false)              |   
+| `<generate[uuid]>`                  | Injects a randomly generated UUID                  |   
 
 ## Full example
 Example contract definition in YAML.   
@@ -207,16 +259,16 @@ contract:
     headers:
       Content-Type: application/json
     body:
-      customer: John Doe
+      customer: <generate[string]>
       items:
         - product: Hamburger
           quantity: 2
           price: 20
         - product: Fries
           quantity: 1
-          price: 10
+          price: <generate[number(min=5;max=25)]>
     params:
-      orderId: 1337
+      orderId: <generate[number]>
   response:
     statusCode: 200
     headers:

--- a/contracts/token-api/v1/init_seed_post.yml
+++ b/contracts/token-api/v1/init_seed_post.yml
@@ -1,0 +1,15 @@
+contract:
+  request:
+    path: /api/v1/tokens/init
+    method: POST
+    body:
+      username: myUsername
+      userSeed: <generate[string(length=32)]>
+      loginCount: <generate[number(min=1337;max=7331)]>
+      nonce: <generate[uuid]>
+  response:
+    statusCode: 200
+    body:
+      accepted: true
+      token: <anyString>
+      validUntil: 2100-03-22T17:35:00.000+02:00

--- a/package-lock.json
+++ b/package-lock.json
@@ -1625,6 +1625,14 @@
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
         "uuid": "^3.3.3"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "istanbul-lib-report": {
@@ -2111,6 +2119,12 @@
           "requires": {
             "ansi-regex": "^5.0.0"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         },
         "wrap-ansi": {
           "version": "6.2.0",
@@ -2837,10 +2851,9 @@
       }
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.2.0.tgz",
+      "integrity": "sha512-CYpGiFTUrmI6OBMkAdjSDM0k5h8SkkiTP4WAjQgDgNB1S3Ou9VBEvr6q0Kv2H1mMk7IWfxYGpMH5sd5AvcIV2Q=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "js-yaml": "^3.13.1",
     "junit-report-builder": "^1.3.3",
-    "needle": "^2.3.3"
+    "needle": "^2.3.3",
+    "uuid": "^8.2.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/src/parsing/contractparser.js
+++ b/src/parsing/contractparser.js
@@ -103,6 +103,8 @@ ContractParser.prototype.parseContract = function (contractsDirectory, contractF
     normalizeObjectProperty(this.logger, contractYaml.contract.response, "headers", contractName);
     normalizeObjectProperty(this.logger, contractYaml.contract.request, "params", contractName);
 
+    // TODO: Check for <generate> and replace values
+
     return {
         name: contractName,
         data: contractYaml.contract

--- a/src/parsing/wildcard-generator.js
+++ b/src/parsing/wildcard-generator.js
@@ -1,12 +1,27 @@
-module.exports = WildcardGenerator;
+const { v4: uuidv4 } = require('uuid');
 
-const generatorRegex = /<generate\[([a-z]*)\(?([a-z,=,\d,;]*)?\)?\]>/g;
+const generatorRegex = /<generate\[([a-z]*)\(?([a-z=\d;]*)?\)?\]>/g;
 const supportedTypes = [
     "string",
     "number",
     "bool",
     "uuid"
 ];
+const ARGUMENT_DELIMITER = ";";
+const ARGUMENT_VALUE_DELIMITER = "=";
+const DEFAULT_STRING_LENGTH = 10;
+const DEFAULT_NUMBER_MIN = 1;
+const DEFAULT_NUMBER_MAX = 9_999_999;
+
+function generateRandomString(length) {
+    let result = '';
+    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    const charactersLength = characters.length;
+    for ( let i = 0; i < length; i++ ) {
+        result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    }
+    return result;
+}
 
 function parseValue(value) {
     let matches = value.matchAll(generatorRegex);
@@ -15,6 +30,39 @@ function parseValue(value) {
         matchesArr = match;
     }
     return matchesArr;
+}
+
+function parseArguments(arguments) {
+    let generationArguments = arguments || null;
+    if(generationArguments != null) {
+        generationArguments = generationArguments.split(ARGUMENT_DELIMITER).map(function(arg) {
+            arg = arg.split(ARGUMENT_VALUE_DELIMITER);
+            return {
+                argument: arg[0],
+                value: arg[1]
+            }
+        });
+    }
+    return generationArguments;
+}
+
+function filterNamedArgument(arguments, argName, defaultValue) {
+    let namedArgument = arguments.filter(arg => arg.argument === argName);
+    return (namedArgument.length === 0) ? defaultValue : namedArgument[0].value;
+}
+
+function generateRandomNumber(min, max) {
+    min = Math.ceil(min);
+    max = Math.floor(max);
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function generateRandomBoolean() {
+    return Math.random() >= 0.5;
+}
+
+function generateRandomUUID() {
+    return uuidv4();
 }
 
 function WildcardGenerator(logger) {
@@ -32,11 +80,35 @@ WildcardGenerator.prototype.isGenerateWildcard = function(value) {
 
     let generationValueType = matchesArr[1];
     return !(generationValueType === undefined || !supportedTypes.includes(generationValueType));
-
 };
 
 WildcardGenerator.prototype.generateWildcardValue = function(value) {
-    // <generate\[([a-z]*(\({1}(.*)\){1}))\]>
+    let matchesArr = parseValue(value);
+    let generationValueType = matchesArr[1];
+    let generationArguments = parseArguments(matchesArr[2]);
 
+    if(generationValueType === "string") {
+        let lengthValue = DEFAULT_STRING_LENGTH;
+        if(generationArguments != null) {
+            lengthValue = filterNamedArgument(generationArguments, "length", DEFAULT_STRING_LENGTH);
+        }
+        return generateRandomString(lengthValue);
+    }
+    else if(generationValueType === "number") {
+        let minValue = DEFAULT_NUMBER_MIN;
+        let maxValue = DEFAULT_NUMBER_MAX;
+        if(generationArguments != null) {
+            minValue = filterNamedArgument(generationArguments, "min", DEFAULT_NUMBER_MIN);
+            maxValue = filterNamedArgument(generationArguments, "max", DEFAULT_NUMBER_MAX);
+        }
+        return generateRandomNumber(minValue, maxValue);
+    }
+    else if(generationValueType === "bool") {
+        return generateRandomBoolean();
+    }
+    else if(generationValueType === "uuid") {
+        return generateRandomUUID();
+    }
     return value;
 };
+module.exports = WildcardGenerator;

--- a/src/parsing/wildcard-generator.js
+++ b/src/parsing/wildcard-generator.js
@@ -1,29 +1,38 @@
 module.exports = WildcardGenerator;
 
-const generatorRegex = /<generate\[([a-z]*(\(.*\))?)\]>/g;
+const generatorRegex = /<generate\[([a-z]*)\(?([a-z,=,\d,;]*)?\)?\]>/g;
+const supportedTypes = [
+    "string",
+    "number",
+    "bool",
+    "uuid"
+];
+
+function parseValue(value) {
+    let matches = value.matchAll(generatorRegex);
+    let matchesArr = [];
+    for (const match of matches) {
+        matchesArr = match;
+    }
+    return matchesArr;
+}
 
 function WildcardGenerator(logger) {
     this.logger = logger;
 }
 
 WildcardGenerator.prototype.isGenerateWildcard = function(value) {
-    // will output array of matches, or null
-    // let matches = generatorRegex.exec(value);
-    let matches = value.matchAll(generatorRegex);
-    for (const match of matches) {
-        console.log(match);
-        console.log(match.index)
+    const valueType = typeof value;
+    if(valueType !== "string") {
+        return false;
     }
-    // console.log(matches);
-    if (matches === null) return false;
 
-    let generationValueType = matches[1];
-    let generationArguments = matches[2];
-    console.log(generationValueType);
-    console.log(generationArguments)
+    let matchesArr = parseValue(value);
+    if (matchesArr === null) return false;
 
-    let valueType = typeof value;
-    return valueType === 'string'
+    let generationValueType = matchesArr[1];
+    return !(generationValueType === undefined || !supportedTypes.includes(generationValueType));
+
 };
 
 WildcardGenerator.prototype.generateWildcardValue = function(value) {

--- a/src/parsing/wildcard-generator.js
+++ b/src/parsing/wildcard-generator.js
@@ -11,7 +11,7 @@ const ARGUMENT_DELIMITER = ";";
 const ARGUMENT_VALUE_DELIMITER = "=";
 const DEFAULT_STRING_LENGTH = 10;
 const DEFAULT_NUMBER_MIN = 1;
-const DEFAULT_NUMBER_MAX = 9_999_999;
+const DEFAULT_NUMBER_MAX = 9999999;
 
 function generateRandomString(length) {
     let result = '';

--- a/src/parsing/wildcard-generator.js
+++ b/src/parsing/wildcard-generator.js
@@ -1,0 +1,14 @@
+module.exports = WildcardGenerator;
+
+function WildcardGenerator(logger) {
+    this.logger = logger;
+}
+
+WildcardGenerator.prototype.isGenerateWildcard = function(value) {
+    let valueType = typeof value;
+    return valueType === 'string'
+};
+
+WildcardGenerator.prototype.generateWildcardValue = function(value) {
+    return value;
+};

--- a/src/parsing/wildcard-generator.js
+++ b/src/parsing/wildcard-generator.js
@@ -1,14 +1,33 @@
 module.exports = WildcardGenerator;
 
+const generatorRegex = /<generate\[([a-z]*(\(.*\))?)\]>/g;
+
 function WildcardGenerator(logger) {
     this.logger = logger;
 }
 
 WildcardGenerator.prototype.isGenerateWildcard = function(value) {
+    // will output array of matches, or null
+    // let matches = generatorRegex.exec(value);
+    let matches = value.matchAll(generatorRegex);
+    for (const match of matches) {
+        console.log(match);
+        console.log(match.index)
+    }
+    // console.log(matches);
+    if (matches === null) return false;
+
+    let generationValueType = matches[1];
+    let generationArguments = matches[2];
+    console.log(generationValueType);
+    console.log(generationArguments)
+
     let valueType = typeof value;
     return valueType === 'string'
 };
 
 WildcardGenerator.prototype.generateWildcardValue = function(value) {
+    // <generate\[([a-z]*(\({1}(.*)\){1}))\]>
+
     return value;
 };

--- a/test/parsing/contractparser.spec.js
+++ b/test/parsing/contractparser.spec.js
@@ -758,6 +758,33 @@ describe("ContractParser", () => {
                 expect(typeof item).to.equal("string");
             });
         });
+
+        it("should not replace a value with a random value when request contains unsupported generator keyword", () => {
+            const keyword = "<generate[problem]>"
+            const yamlContent = {
+                contract: {
+                    request: {
+                        path: "/some/path",
+                        body: {
+                            username: keyword
+                        }
+                    },
+                    response: {
+                        statusCode: 200
+                    }
+                }
+            };
+            mockYamlLoading(yamlContent);
+
+            const parser = new ContractParser(TESTLOGGER);
+            let result = parser.parseContract(testBaseDir, testFilePath3);
+
+            expect(result.data).to.equal(yamlContent.contract);
+            expect(result.name).to.equal(testFileName3);
+            const generatedValue = result.data.request.body.username;
+            expect(generatedValue).to.equal(keyword);
+            expect(typeof generatedValue).to.equal("string");
+        });
         //endregion
     })
 });

--- a/test/parsing/contractparser.spec.js
+++ b/test/parsing/contractparser.spec.js
@@ -550,7 +550,7 @@ describe("ContractParser", () => {
             const generatedValue = result.data.request.body.username;
             expect(typeof generatedValue).to.equal("number");
             expect(generatedValue).to.be.at.least(1);
-            expect(generatedValue).to.be.at.most(9_999_999);
+            expect(generatedValue).to.be.at.most(9999999);
         });
 
         it("should replace a value with a random number when request contains generator keyword for number with max param", () => {
@@ -604,7 +604,7 @@ describe("ContractParser", () => {
             const generatedValue = result.data.request.body.username;
             expect(typeof generatedValue).to.equal("number");
             expect(generatedValue).to.be.at.least(10);
-            expect(generatedValue).to.be.at.most(9_999_999);
+            expect(generatedValue).to.be.at.most(9999999);
         });
 
         it("should replace a value with a random number when request contains generator keyword for number with two params", () => {

--- a/test/parsing/contractparser.spec.js
+++ b/test/parsing/contractparser.spec.js
@@ -548,8 +548,9 @@ describe("ContractParser", () => {
             expect(result.data).to.equal(yamlContent.contract);
             expect(result.name).to.equal(testFileName3);
             const generatedValue = result.data.request.body.username;
-            expect(generatedValue).to.not.contain("generate");
             expect(typeof generatedValue).to.equal("number");
+            expect(generatedValue).to.be.at.least(1);
+            expect(generatedValue).to.be.at.most(9_999_999);
         });
 
         it("should replace a value with a random number when request contains generator keyword for number with max param", () => {
@@ -574,8 +575,8 @@ describe("ContractParser", () => {
             expect(result.data).to.equal(yamlContent.contract);
             expect(result.name).to.equal(testFileName3);
             const generatedValue = result.data.request.body.username;
-            expect(generatedValue).to.not.contain("generate");
             expect(typeof generatedValue).to.equal("number");
+            expect(generatedValue).to.be.at.least(1);
             expect(generatedValue).to.be.at.most(31);
         });
 
@@ -601,9 +602,9 @@ describe("ContractParser", () => {
             expect(result.data).to.equal(yamlContent.contract);
             expect(result.name).to.equal(testFileName3);
             const generatedValue = result.data.request.body.username;
-            expect(generatedValue).to.not.contain("generate");
             expect(typeof generatedValue).to.equal("number");
             expect(generatedValue).to.be.at.least(10);
+            expect(generatedValue).to.be.at.most(9_999_999);
         });
 
         it("should replace a value with a random number when request contains generator keyword for number with two params", () => {
@@ -628,10 +629,9 @@ describe("ContractParser", () => {
             expect(result.data).to.equal(yamlContent.contract);
             expect(result.name).to.equal(testFileName3);
             const generatedValue = result.data.request.body.username;
-            expect(generatedValue).to.not.contain("generate");
             expect(typeof generatedValue).to.equal("number");
-            expect(generatedValue).to.be.at.most(31);
             expect(generatedValue).to.be.at.least(10);
+            expect(generatedValue).to.be.at.most(31);
         });
 
         it("should replace a value with a random boolean when request contains generator keyword for boolean", () => {
@@ -656,7 +656,6 @@ describe("ContractParser", () => {
             expect(result.data).to.equal(yamlContent.contract);
             expect(result.name).to.equal(testFileName3);
             const generatedValue = result.data.request.body.username;
-            expect(generatedValue).to.not.contain("generate");
             expect(typeof generatedValue).to.equal("boolean");
         });
 
@@ -683,7 +682,7 @@ describe("ContractParser", () => {
             expect(result.name).to.equal(testFileName3);
             const generatedValue = result.data.request.body.username;
             expect(generatedValue).to.not.contain("generate");
-            expect(typeof generatedValue).to.equal("boolean");
+            expect(generatedValue).to.contain("-");
         });
 
         it("should replace a value with a random string when deep property contains generator keyword for string", () => {
@@ -753,6 +752,7 @@ describe("ContractParser", () => {
             expect(generatedStringValue).to.not.contain("generate");
             expect(typeof generatedStringValue).to.equal("string");
             const generatedArray = result.data.request.body.user.tokens;
+            console.log(generatedArray);
             generatedArray.forEach(function(item) {
                 expect(item).to.not.contain("generate");
                 expect(typeof item).to.equal("string");

--- a/test/parsing/contractparser.spec.js
+++ b/test/parsing/contractparser.spec.js
@@ -685,6 +685,79 @@ describe("ContractParser", () => {
             expect(generatedValue).to.not.contain("generate");
             expect(typeof generatedValue).to.equal("boolean");
         });
+
+        it("should replace a value with a random string when deep property contains generator keyword for string", () => {
+            const yamlContent = {
+                contract: {
+                    request: {
+                        path: "/some/path",
+                        body: {
+                            user: {
+                                name: "<generate[string]>",
+                                id: {
+                                    type: "UUID",
+                                    value: "<generate[uuid]>"
+                                }
+                            }
+                        }
+                    },
+                    response: {
+                        statusCode: 200
+                    }
+                }
+            };
+            mockYamlLoading(yamlContent);
+
+            const parser = new ContractParser(TESTLOGGER);
+            let result = parser.parseContract(testBaseDir, testFilePath3);
+
+            expect(result.data).to.equal(yamlContent.contract);
+            expect(result.name).to.equal(testFileName3);
+            const generatedStringValue = result.data.request.body.user.name;
+            expect(generatedStringValue).to.not.contain("generate");
+            expect(typeof generatedStringValue).to.equal("string");
+            const generatedUuidValue = result.data.request.body.user.id.value;
+            expect(generatedUuidValue).to.not.contain("generate");
+            expect(typeof generatedUuidValue).to.equal("string");
+        });
+
+        it("should replace a value with a random string when deep array property contains generator keyword for string", () => {
+            const yamlContent = {
+                contract: {
+                    request: {
+                        path: "/some/path",
+                        body: {
+                            user: {
+                                name: "<generate[string]>",
+                                tokens: [
+                                    "<generate[uuid]>",
+                                    "<generate[uuid]>",
+                                    "<generate[uuid]>"
+                                ]
+                            }
+                        }
+                    },
+                    response: {
+                        statusCode: 200
+                    }
+                }
+            };
+            mockYamlLoading(yamlContent);
+
+            const parser = new ContractParser(TESTLOGGER);
+            let result = parser.parseContract(testBaseDir, testFilePath3);
+
+            expect(result.data).to.equal(yamlContent.contract);
+            expect(result.name).to.equal(testFileName3);
+            const generatedStringValue = result.data.request.body.user.name;
+            expect(generatedStringValue).to.not.contain("generate");
+            expect(typeof generatedStringValue).to.equal("string");
+            const generatedArray = result.data.request.body.user.tokens;
+            generatedArray.forEach(function(item) {
+                expect(item).to.not.contain("generate");
+                expect(typeof item).to.equal("string");
+            });
+        });
         //endregion
     })
 });

--- a/test/parsing/wildcardgenerator.spec.js
+++ b/test/parsing/wildcardgenerator.spec.js
@@ -17,6 +17,7 @@ describe("WildcardGenerator", () => {
     ];
     const unsupportedValues = [
         "<generate[problem]>",
+        "<generate[problem(this=test)]>",
         "some string that is not supported",
         1,
         true,
@@ -76,9 +77,9 @@ describe("WildcardGenerator", () => {
 
             let result = generator.generateWildcardValue("<generate[number]>")
 
-            expect(result).to.not.contain("generate");
-            expect(result).to.not.contain("number");
             expect(typeof result).to.equal("number");
+            expect(result).to.be.at.least(1);
+            expect(result).to.be.at.most(9_999_999);
         });
 
         it("should replace a value with a random number when request contains generator keyword for number with max param", () => {
@@ -86,10 +87,8 @@ describe("WildcardGenerator", () => {
 
             let result = generator.generateWildcardValue("<generate[number(max=31)]>")
 
-            expect(result).to.not.contain("generate");
-            expect(result).to.not.contain("number");
-            expect(result).to.not.contain("max");
             expect(typeof result).to.equal("number");
+            expect(result).to.be.at.least(1);
             expect(result).to.be.at.most(31);
         });
 
@@ -98,11 +97,9 @@ describe("WildcardGenerator", () => {
 
             let result = generator.generateWildcardValue("<generate[number(min=10)]>")
 
-            expect(result).to.not.contain("generate");
-            expect(result).to.not.contain("number");
-            expect(result).to.not.contain("min");
             expect(typeof result).to.equal("number");
             expect(result).to.be.at.least(10);
+            expect(result).to.be.at.most(9_999_999);
         });
 
         it("should replace a value with a random number when request contains generator keyword for number with two params", () => {
@@ -110,13 +107,19 @@ describe("WildcardGenerator", () => {
 
             let result = generator.generateWildcardValue("<generate[number(min=10;max=31)]>")
 
-            expect(result).to.not.contain("generate");
-            expect(result).to.not.contain("number");
-            expect(result).to.not.contain("min");
-            expect(result).to.not.contain("max");
             expect(typeof result).to.equal("number");
-            expect(result).to.be.at.most(31);
             expect(result).to.be.at.least(10);
+            expect(result).to.be.at.most(31);
+        });
+
+        it("should replace a value with a random number when request contains generator keyword for number with two params where min > max", () => {
+            const generator = new WildcardGenerator(TESTLOGGER);
+
+            let result = generator.generateWildcardValue("<generate[number(min=31;max=10)]>")
+
+            expect(typeof result).to.equal("number");
+            expect(result).to.be.at.least(10);
+            expect(result).to.be.at.most(31);
         });
 
         it("should replace a value with a random boolean when request contains generator keyword for boolean", () => {
@@ -124,15 +127,13 @@ describe("WildcardGenerator", () => {
 
             let result = generator.generateWildcardValue("<generate[bool]>")
 
-            expect(result).to.not.contain("generate");
-            expect(result).to.not.contain("bool");
             expect(typeof result).to.equal("boolean");
         });
 
         it("should replace a value with a random UUID when request contains generator keyword for uuid", () => {
             const generator = new WildcardGenerator(TESTLOGGER);
 
-            let result = generator.generateWildcardValue("<generate[uuid]>")
+            let result = generator.generateWildcardValue("<generate[uuid]>");
 
             expect(result).to.not.contain("generate");
             expect(result).to.not.contain("uuid");
@@ -141,6 +142,15 @@ describe("WildcardGenerator", () => {
 
         it("should not replace a value with a random value when request contains unsupported generator keyword", () => {
             const keyword = "<generate[problem]>"
+            const generator = new WildcardGenerator(TESTLOGGER);
+
+            let result = generator.generateWildcardValue(keyword)
+
+            expect(result).to.equal(keyword);
+        });
+
+        it("should not replace a value with a random value when request contains unsupported generator keyword", () => {
+            const keyword = "<generate[problem(this=test)]>"
             const generator = new WildcardGenerator(TESTLOGGER);
 
             let result = generator.generateWildcardValue(keyword)

--- a/test/parsing/wildcardgenerator.spec.js
+++ b/test/parsing/wildcardgenerator.spec.js
@@ -1,0 +1,142 @@
+const chai = require("chai");
+const expect = chai.expect;
+const Logging = require("../../src/logging/logging.js");
+const WildcardGenerator = require("../../src/parsing/wildcard-generator.js");
+const TESTLOGGER = new Logging("error", false, false);
+
+describe("WildcardGenerator", () => {
+    const supportedValues = [
+        "<generate[string]>",
+        "<generate[string(length=64)]>",
+        "<generate[number]>",
+        "<generate[number(max=31)]>",
+        "<generate[number(min=10)]>",
+        "<generate[number(min=10;max=31)]>",
+        "<generate[bool]>",
+        "<generate[uuid]>"
+    ];
+
+    describe("isGenerateWildcard", () => {
+        // Define test case for each supported value
+        supportedValues.forEach((testValue) => {
+            it("should return true when given " + testValue, () => {
+                const generator = new WildcardGenerator(TESTLOGGER);
+
+                const result = generator.isGenerateWildcard(testValue)
+
+                expect(result).to.be.true;
+            });
+        });
+
+        const problemCase = "<generate[problem]>"
+        it("should return false when given " + problemCase, () => {
+            const generator = new WildcardGenerator(TESTLOGGER);
+
+            const result = generator.isGenerateWildcard(problemCase)
+
+            expect(result).to.be.false;
+        });
+    });
+
+    describe("generateWildcardValue", () => {
+        it("should replace a value with a random string when request contains generator keyword for string", () => {
+            const generator = new WildcardGenerator(TESTLOGGER);
+
+            let result = generator.generateWildcardValue("<generate[string]>")
+
+            expect(result).to.not.contain("generate");
+            expect(result).to.not.contain("string");
+            expect(typeof result).to.equal("string");
+            expect(result.length).to.equal(10);
+        });
+
+        it("should replace a value with a random string when request contains generator keyword for string with length param", () => {
+            const generator = new WildcardGenerator(TESTLOGGER);
+
+            let result = generator.generateWildcardValue("<generate[string(length=64)]>")
+
+            expect(result).to.not.contain("generate");
+            expect(result).to.not.contain("string");
+            expect(result).to.not.contain("length");
+            expect(typeof result).to.equal("string");
+            expect(result.length).to.equal(64);
+        });
+
+        it("should replace a value with a random number when request contains generator keyword for number", () => {
+            const generator = new WildcardGenerator(TESTLOGGER);
+
+            let result = generator.generateWildcardValue("<generate[number]>")
+
+            expect(result).to.not.contain("generate");
+            expect(result).to.not.contain("number");
+            expect(typeof result).to.equal("number");
+        });
+
+        it("should replace a value with a random number when request contains generator keyword for number with max param", () => {
+            const generator = new WildcardGenerator(TESTLOGGER);
+
+            let result = generator.generateWildcardValue("<generate[number(max=31)]>")
+
+            expect(result).to.not.contain("generate");
+            expect(result).to.not.contain("number");
+            expect(result).to.not.contain("max");
+            expect(typeof result).to.equal("number");
+            expect(result).to.be.at.most(31);
+        });
+
+        it("should replace a value with a random number when request contains generator keyword for number with min param", () => {
+            const generator = new WildcardGenerator(TESTLOGGER);
+
+            let result = generator.generateWildcardValue("<generate[number(min=10)]>")
+
+            expect(result).to.not.contain("generate");
+            expect(result).to.not.contain("number");
+            expect(result).to.not.contain("min");
+            expect(typeof result).to.equal("number");
+            expect(result).to.be.at.least(10);
+        });
+
+        it("should replace a value with a random number when request contains generator keyword for number with two params", () => {
+            const generator = new WildcardGenerator(TESTLOGGER);
+
+            let result = generator.generateWildcardValue("<generate[number(min=10;max=31)]>")
+
+            expect(result).to.not.contain("generate");
+            expect(result).to.not.contain("number");
+            expect(result).to.not.contain("min");
+            expect(result).to.not.contain("max");
+            expect(typeof result).to.equal("number");
+            expect(result).to.be.at.most(31);
+            expect(result).to.be.at.least(10);
+        });
+
+        it("should replace a value with a random boolean when request contains generator keyword for boolean", () => {
+            const generator = new WildcardGenerator(TESTLOGGER);
+
+            let result = generator.generateWildcardValue("<generate[bool]>")
+
+            expect(result).to.not.contain("generate");
+            expect(result).to.not.contain("bool");
+            expect(typeof result).to.equal("boolean");
+        });
+
+        it("should replace a value with a random UUID when request contains generator keyword for uuid", () => {
+            const generator = new WildcardGenerator(TESTLOGGER);
+
+            let result = generator.generateWildcardValue("<generate[uuid]>")
+
+            expect(result).to.not.contain("generate");
+            expect(result).to.not.contain("uuid");
+            expect(typeof result).to.equal("string");
+        });
+
+        it("should not replace a value with a random value when request contains unsupported generator keyword", () => {
+            const keyword = "<generate[problem]>"
+            const generator = new WildcardGenerator(TESTLOGGER);
+
+            let result = generator.generateWildcardValue(keyword)
+
+            expect(result).to.equal(keyword);
+        });
+    });
+});

--- a/test/parsing/wildcardgenerator.spec.js
+++ b/test/parsing/wildcardgenerator.spec.js
@@ -15,6 +15,13 @@ describe("WildcardGenerator", () => {
         "<generate[bool]>",
         "<generate[uuid]>"
     ];
+    const unsupportedValues = [
+        "<generate[problem]>",
+        "some string that is not supported",
+        1,
+        true,
+        "weOnlySupportGenerate[]stuff"
+    ]
 
     describe("isGenerateWildcard", () => {
         // Define test case for each supported value
@@ -28,13 +35,15 @@ describe("WildcardGenerator", () => {
             });
         });
 
-        const problemCase = "<generate[problem]>"
-        it("should return false when given " + problemCase, () => {
-            const generator = new WildcardGenerator(TESTLOGGER);
+        // Failing cases
+        unsupportedValues.forEach((problemCase) => {
+            it("should return false when given " + problemCase, () => {
+                const generator = new WildcardGenerator(TESTLOGGER);
 
-            const result = generator.isGenerateWildcard(problemCase)
+                const result = generator.isGenerateWildcard(problemCase)
 
-            expect(result).to.be.false;
+                expect(result).to.be.false;
+            });
         });
     });
 

--- a/test/parsing/wildcardgenerator.spec.js
+++ b/test/parsing/wildcardgenerator.spec.js
@@ -79,7 +79,7 @@ describe("WildcardGenerator", () => {
 
             expect(typeof result).to.equal("number");
             expect(result).to.be.at.least(1);
-            expect(result).to.be.at.most(9_999_999);
+            expect(result).to.be.at.most(9999999);
         });
 
         it("should replace a value with a random number when request contains generator keyword for number with max param", () => {
@@ -99,7 +99,7 @@ describe("WildcardGenerator", () => {
 
             expect(typeof result).to.equal("number");
             expect(result).to.be.at.least(10);
-            expect(result).to.be.at.most(9_999_999);
+            expect(result).to.be.at.most(9999999);
         });
 
         it("should replace a value with a random number when request contains generator keyword for number with two params", () => {


### PR DESCRIPTION
Note: Dropped Node 10 and 11 because they do not support `<string>.matchAll()`